### PR TITLE
Adding a conferences directory.

### DIFF
--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -84,12 +84,14 @@ We plan discuss the following strategic topics:
 
 3. Should the lessons be teachable as stand-alone sessions, with resultant overlap of material, or should the lessons form a "deck" that workshop coordinators can mix and match?
 
-4. The current HPC Intro lesson has templates for customization to local resources. There is obvious tension between having flexible templates versus ease of set-up.
+4. How should we use existing complementary material? There are resources available on some of our aspirational topics (containers, Julia), should we incorporate these into workshops, or build our own lessons from them?
+
+5. The current HPC Intro lesson has templates for customization to local resources. There is obvious tension between having flexible templates versus ease of set-up.
 
     - How much templating is useful? At what point does it become burdensome?
     - Should the material be adapted to permanent on-premise resources, or transient cloud resources?
 
-5. What duration of workshop is practical for teaching this material?
+6. What duration of workshop is practical for teaching this material?
 
     - Half-day?
     - Full day?

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -80,7 +80,7 @@ We plan discuss the following strategic topics:
 
     - Existing lessons are fine, effort should go to improving them.
     - HPC applications of new languages -- Julia, Chapel, Python.
-    - HPC frameworks -- Containers, Dask, MPI, MPI, parallel CUDA.
+    - HPC frameworks -- Containers, Dask, MPI, parallel CUDA.
 
 3. Should the lessons be teachable as stand-alone sessions, with resultant overlap of material, or should the lessons form a "deck" that workshop coordinators can mix and match?
 

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -18,7 +18,7 @@ It's possible to include a brief bio for these.
 users to high-performance computing resources. As these resources
 become more common, the need for educational resources to bring users from a
 broad variety of technical backgrounds up to speed becomes more urgent. Based
-on the pedagogically sound methods of the larger [Carpentries][2] method,
+on the pedagogically well-founded methods of the larger [Carpentries][2] approach,
 lessons in active development include an [introduction][3] to the use of a
 queuing system, an introduction to [parallel programming in Python][4], and a
 lesson focusing on the [Chapel parallel language][5]. The introductory lesson

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -54,18 +54,19 @@ submitted to the [Carpentries Incubator][7], where it benefits from
 input from the broader Carpentries audience.  Another important lesson
 in development is a [parallel python][4] lesson.
 
-Many community members have important operational experience with a
-variety of HPC tools in a pedagogical context, including the design,
+Many of our community members have important operational experience with
+a variety of HPC tools in a pedagogical context, including the design,
 procurement, deployment, and maintenance of on-premise hardware,
 container, and cloud systems.  This informs the lesson-development
 process at many levels.
 
 ### Goals for the BoF
 
-During this BoF, we will gather community feedback on our progress to date, to
-ensure that we are aligned with current HPC best practices, and to help the HPC
-Carpentries development team prioritize efforts for successor lessons in light
-of the changing landscape of current HPC practice.
+During this BoF, we will gather community feedback on our progress to
+date, to ensure that we are helping HPC operators bring users on board,
+and helping users make good use of the systems. This will help the HPC
+Carpentry development team prioritize efforts for successor lessons in
+light of the changing landscape of current HPC practice.
 
 We plan discuss the following strategic topics:
 
@@ -75,11 +76,11 @@ We plan discuss the following strategic topics:
     - Was the HPC Carpentry material used stand-alone, or in combination with other material?
     - What sequence was used? 
 
-2. Our existing lessons are not uniformly developed, and we have many good ideas for future lessons.
+2. Our existing lessons are not uniformly developed, and we have many good ideas for future lessons. Where should we focus future lesson efforts?
 
-    - Where should we focus efforts for future lessons?
-    - Languages? Julia? Chapel? Python?
-    - Frameworks? MPI? Dask? Containers?
+    - Existing lessons are fine, effort should go to improving them.
+    - HPC applications of new languages -- Julia, Chapel, Python.
+    - HPC frameworks -- Containers, Dask, MPI, MPI, parallel CUDA.
 
 3. Should the lessons be teachable as stand-alone sessions, with resultant overlap of material, or should the lessons form a "deck" that workshop coordinators can mix and match?
 
@@ -88,7 +89,7 @@ We plan discuss the following strategic topics:
     - How much templating is useful? At what point does it become burdensome?
     - Should the material be adapted to permanent on-premise resources, or transient cloud resources?
 
-5. What duration of workshop is practical for users of this material?
+5. What duration of workshop is practical for teaching this material?
 
     - Half-day?
     - Full day?

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -3,7 +3,12 @@
 ## Session Leaders
 
 Andrew Reid
-: On GitHub [@reid-a][reid-a].
+: he/him. Computer operations administrator for the [CTCMS][ctcms]
+  clusters at [NIST][nist], managing a rotating cast of cluster 
+  users of varying levels of experience. Also materials scientist 
+  and co-developer of the [OOF][oof] finite-element tool, 
+  facilitating structure-property exploration for other materials 
+  scientists.  On GitHub [@reid-a][reid-a].
 
 Trevor Keller
 : they/them. Materials research engineer at [NIST][nist] and inchoate
@@ -164,6 +169,7 @@ fifteen participants got together at SC18.
 
 [nist]: https://www.nist.gov
 [ctcms]: https://www.ctcms.nist.gov
+[oof]: https://www.ctcms.nist.gov/oof/
 
 [annajiat]: https://github.com/annajiat
 [ocaisa]:   https://github.com/ocaisa

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -41,7 +41,7 @@ to new environments; educational resources to bring users up to speed
 become more significant. Based on the approach of [The Carpentries][2],
 HPC Carpentry lessons in development include an [introduction][3] to the
 use of a queuing system and an introduction to [parallel programming
-in Python][4]. The introductory lesson is part of the [Incubator][7],
+in Python][4]. The queuing lesson is part of the [Incubator][7],
 where it benefits from the broader Carpentries community.
 
 ## Long description:
@@ -54,8 +54,7 @@ a number of introductory lessons for new users of HPC systems.
 
 ### What problem we solve
 
-Greater computational capabilities are becoming increasingly
-affordable. An under-appreciated consequence of this is that the range
+An under-appreciated consequence of the growth of HPC is that the range
 of backgrounds of new users of these resources is increasingly broad,
 and may not include knowledge of computer system configurations and
 file system layouts. This prevents users from making effective use of
@@ -72,17 +71,17 @@ in development uses Python and MPI to introduce the basics of
 [parallel programming][4].
 
 Many of our community members have important operational experience with
-a variety of HPC tools in a pedagogical context, including the design,
-procurement, deployment, and maintenance of on-premise hardware,
+a variety of HPC tools in a pedagogical context, including the
+operation of on-premise hardware,
 container, and cloud systems. This informs the lesson-development
 process at many levels.
 
 ### Goals for the BoF
 
-During this BoF, we will gather community feedback on our progress to
-date, to ensure that we are helping HPC operators bring users on board,
-and helping users make good use of the systems. This will help the HPC
-Carpentry development team prioritize efforts for successor lessons in
+During this BoF, we will gather community feedback 
+to ensure that we are helping HPC operators bring users on board,
+and helping users make good use of the systems. This will help 
+prioritize efforts for successor lessons in
 light of the changing landscape of current HPC practice.
 
 We plan discuss the following strategic topics:
@@ -94,8 +93,8 @@ We plan discuss the following strategic topics:
       with material from The Carpentries or elsewhere?
     - What sequence of lessons was used to build the workshop?
 
-2. Our existing lessons are not uniformly developed, and we have many
-   good ideas for future lessons. Which to prioritize?
+2. Our existing lessons are not uniformly developed. How should we
+   prioritize future development?
 
     - Existing lessons cover the important topics. Effort should go to
       improving them.

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -37,15 +37,14 @@ number of introductory lessons for new users of HPC systems.
 
 ### What problem we solve
 
-It is a cliche at this point that greater and greater computational
-capabilities are becoming increasingly affordable. An under-appreciated
-consequence of this is that the range of backgrounds of new users of
-these resources is increasingly broad, and may not include knowledge of
-computer system configurations and file system layouts. This prevents
-users from making effective use of these new systems.  There is an evident
-on-going need to address the gap between the skills and expectations of
-users and the capabilities and opportunities presented by the available
-HPC resources.
+Greater computational capabilities are becoming increasingly
+affordable. An under-appreciated consequence of this is that the range
+of backgrounds of new users of these resources is increasingly broad,
+and may not include knowledge of computer system configurations and
+file system layouts. This prevents users from making effective use of
+these new systems.  There is an evident on-going need to address the
+gap between the skills and expectations of users and the capabilities
+and opportunities presented by the available HPC resources.
 
 The [HPC Carpentry][1] lessons address this gap, building on the
 pedagogically sound instructional methods of the larger [Carpentries][2]
@@ -76,7 +75,7 @@ We plan discuss the following strategic topics:
     - Was the HPC Carpentry material used stand-alone, or in combination with other material?
     - What sequence was used? 
 
-2. Our existing lessons are not uniformly developed, and we have many good ideas for future lessons. Where should we focus future lesson efforts?
+2. Our existing lessons are not uniformly developed, and we have many good ideas for future lessons. Which to prioritize?
 
     - Existing lessons are fine, effort should go to improving them.
     - HPC applications of new languages -- Julia, Chapel, Python.
@@ -88,7 +87,7 @@ We plan discuss the following strategic topics:
 
 5. The current HPC Intro lesson has templates for customization to local resources. There is obvious tension between having flexible templates versus ease of set-up.
 
-    - How much templating is useful? At what point does it become burdensome?
+    - How much templating is useful? How much is burdensome?
     - Should the material be adapted to permanent on-premise resources, or transient cloud resources?
 
 6. What duration of workshop is practical for teaching this material?

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -1,4 +1,3 @@
-
 ## Title: HPC Carpentry: Introducing New Users to HPC
 
 ## Session Leaders
@@ -15,28 +14,60 @@ It's possible to include a brief bio for these.
 
 ## Abstract:
 
-[HPC Carpentry][1] is a community and a set of lessons for introducing new users to cluster-based high-performance computing resources.  As these resources become more common, the need for educational resources to bring users from a broad variety of technical backgrounds up to speed becomes more urgent.  Based on the pedagogically sound methods of the larger [Carpentries][2] method, lessons in active development include an [introduction][3] to the use of a queuing system, an introduction to [parallel programming in Python][4], and a lesson focusing on the [Chapel parallel language][5].  The introductory lesson is part of the Carpentries incubator program, and is on track to be incorporated in to the Carpentries as a regular lesson in the near future.
+[HPC Carpentry][1] is a community and a set of lessons for introducing new
+users to cluster-based high-performance computing resources. As these resources
+become more common, the need for educational resources to bring users from a
+broad variety of technical backgrounds up to speed becomes more urgent. Based
+on the pedagogically sound methods of the larger [Carpentries][2] method,
+lessons in active development include an [introduction][3] to the use of a
+queuing system, an introduction to [parallel programming in Python][4], and a
+lesson focusing on the [Chapel parallel language][5]. The introductory lesson
+is part of the Carpentries incubator program, and is on track to be
+incorporated in to the Carpentries as a regular lesson in the near future.
 
   
 ##  Long description:
 
 ### Who we are
 
-The [HPC Carpentry][1] community, a volunteer group of high-performance computing practitioners lead by a [steering committee][6], has developed a number of introductory lessons for new users of HPC clusters. 
+The [HPC Carpentry][1] community, a volunteer group of high-performance
+computing practitioners lead by a [steering committee][6], has developed a
+number of introductory lessons for new users of HPC clusters.
 
 ### What Problem We Solve
 
-It is almost a cliche at this point that greater and greater computational capabilities are becoming increasingly affordable.  An under-appreciated consequence of this is that the range of backgrounds of new users of these resources is increasingly broad, and may not include knowledge of computer system configurations and file system layouts.  There is an evident on-going need to address the gap between the needs of these users and the capabilities and opportunities presented by the available HPC resources.
+It is almost a cliche at this point that greater and greater computational
+capabilities are becoming increasingly affordable. An under-appreciated
+consequence of this is that the range of backgrounds of new users of these
+resources is increasingly broad, and may not include knowledge of computer
+system configurations and file system layouts. There is an evident on-going
+need to address the gap between the needs of these users and the capabilities
+and opportunities presented by the available HPC resources.
 
-The [HPC Carpentry][1] lessons address this gap, building on the pedagogically sound instructional methods of the larger [Carpentries][2] community to develop several lessons.  The best-developed of these, the [HPC Intro][3] lesson, was recently submitted to the [Carpentries Incubator][7] program, and is on track to become an official [Carpentries][2] lesson.  Other important lessons in development include a [parallel python][4] lesson, and a lesson focusing on the [chapel][5] language.
+The [HPC Carpentry][1] lessons address this gap, building on the pedagogically
+sound instructional methods of the larger [Carpentries][2] community to develop
+several lessons. The best-developed of these, the [HPC Intro][3] lesson, was
+recently submitted to the [Carpentries Incubator][7] program, and is on track
+to become an official [Carpentries][2] lesson. Other important lessons in
+development include a [parallel python][4] lesson, and a lesson focusing on the
+[chapel][5] language.
 
 ### Goals for the BoF
 
-During this BoF, we will gather community feedback on our progress to date, to ensure that we are aligned with current HPC best practices, and to help the HPC Carpentries development team prioritize efforts for successor lessons in light of the changing landscape of current HPC practice.  
+During this BoF, we will gather community feedback on our progress to date, to
+ensure that we are aligned with current HPC best practices, and to help the HPC
+Carpentries development team prioritize efforts for successor lessons in light
+of the changing landscape of current HPC practice.
 
-MPI remains a very popular parallel framework, but the community of novice HPC users may be using codes for which the MPI details are hidden, or which use entirely different parallel frameworks.  What is the right level of detail to address parallel frameworks in the introductory and advanced levels?
+MPI remains a very popular parallel framework, but the community of novice HPC
+users may be using codes for which the MPI details are hidden, or which use
+entirely different parallel frameworks. What is the right level of detail to
+address parallel frameworks in the introductory and advanced levels?
 
-There are many languages in which parallel and HPC codes are written, including legacy Fortran codes, low-level C and C++ codes, and newer HPC codes written in Python, Julia, or other parallel languages.  How can we provide relevant information across these communities, while retaining pedagogical rigor?
+There are many languages in which parallel and HPC codes are written, including
+legacy Fortran codes, low-level C and C++ codes, and newer HPC codes written in
+Python, Julia, or other parallel languages. How can we provide relevant
+information across these communities, while retaining pedagogical rigor?
 
 ## Interactivity
 
@@ -44,7 +75,8 @@ Approximately 2/3 to 3/4 of the session will be interactive.
 
 ## Format of the non-audience-participation portion
 
-Presentations by the session leaders, either with slides or walking through a lesson.
+Presentations by the session leaders, either with slides or walking through a
+lesson.
 
 ## Commercial?
 
@@ -52,11 +84,15 @@ No.
 
 ## Format
 
-The BoF will open with a presentation of the current state of the lessons, including "pain points" identified by the development team, after which an open discussion will be held to solicit feedback on thees points, and the questions above, from the attendees.
+The BoF will open with a presentation of the current state of the lessons,
+including "pain points" identified by the development team, after which an open
+discussion will be held to solicit feedback on thees points, and the questions
+above, from the attendees.
 
 ## Prior BoFs?
 
-An HPC Carpentry BoF was held at SC17, and an informal group of about fifteen participants got together at SC18.
+An HPC Carpentry BoF was held at SC17, and an informal group of about fifteen
+participants got together at SC18.
 
 ## Time, expected attendance, keywords
 

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -4,6 +4,7 @@
 
  - Andrew Reid
  - Trevor Keller
+ - Alan O'Cais
  - Annajiat Alim Rasel
 
 It's possible to include a brief bio for these.
@@ -14,16 +15,16 @@ It's possible to include a brief bio for these.
 
 ## Abstract:
 
-[HPC Carpentry][1] is a community built around a set of community-contributed lessons for introducing new
-users to high-performance computing resources. As these resources
-become more common, the need for educational resources to bring users from a
-broad variety of technical backgrounds up to speed becomes more urgent. Based
-on the pedagogically well-founded methods of the larger [Carpentries][2] approach,
-lessons in active development include an [introduction][3] to the use of a
-queuing system, an introduction to [parallel programming in Python][4], and a
-lesson focusing on the [Chapel parallel language][5]. The introductory lesson
-is part of the [Carpentries Incubator][7] program, and is on track to be
-incorporated in to the Carpentries as a regular lesson in the near future.
+[HPC Carpentry][1] introduces new users to high-performance computing
+through a set of community-contributed lessons.  As diverse and powerful
+hardware becomes more widely deployed, users from a variety of technical
+backgrounds are faced with the challenge of adapting their problems
+to new environments; educational resources to bring users up to speed
+become more significant.  Based on the approach of [The Carpentries][2],
+HPC Carpentry lessons in development include an [introduction][3] to the
+use of a queuing system and an introduction to [parallel programming
+in Python][4].  The introductory lesson is part of the [Incubator][7], 
+where it benefits from the broader Carpentries community.
 
   
 ##  Long description:
@@ -31,26 +32,33 @@ incorporated in to the Carpentries as a regular lesson in the near future.
 ### Who we are
 
 The [HPC Carpentry][1] community, a volunteer group of high-performance
-computing practitioners lead by a [steering committee][6], has developed a
-number of introductory lessons for new users of HPC clusters.
+computing practitioners led by a [steering committee][6], has developed a
+number of introductory lessons for new users of HPC systems.
 
 ### What problem we solve
 
-It is almost a cliche at this point that greater and greater computational
+It is a cliche at this point that greater and greater computational
 capabilities are becoming increasingly affordable. An under-appreciated
-consequence of this is that the range of backgrounds of new users of these
-resources is increasingly broad, and may not include knowledge of computer
-system configurations and file system layouts. There is an evident on-going
-need to address the gap between the needs of these users and the capabilities
-and opportunities presented by the available HPC resources.
+consequence of this is that the range of backgrounds of new users of
+these resources is increasingly broad, and may not include knowledge of
+computer system configurations and file system layouts. This prevents
+users from making effective use of these new systems.  There is an evident
+on-going need to address the gap between the skills and expectations of
+users and the capabilities and opportunities presented by the available
+HPC resources.
 
-The [HPC Carpentry][1] lessons address this gap, building on the pedagogically
-sound instructional methods of the larger [Carpentries][2] community to develop
-several lessons. The best-developed of these, the [HPC Intro][3] lesson, was
-recently submitted to the [Carpentries Incubator][7] program, and is on track
-to become an official [Carpentries][2] lesson. Other important lessons in
-development include a [parallel python][4] lesson, and a lesson focusing on the
-[chapel][5] language.
+The [HPC Carpentry][1] lessons address this gap, building on the
+pedagogically sound instructional methods of the larger [Carpentries][2]
+community.  The best-developed lesson, [HPC Intro][3], was recently
+submitted to the [Carpentries Incubator][7], where it benefits from
+input from the broader Carpentries audience.  Another important lesson
+in development is a [parallel python][4] lesson.
+
+Many community members have important operational experience with a
+variety of HPC tools in a pedagogical context, including the design,
+procurement, deployment, and maintenance of on-premise hardware,
+container, and cloud systems.  This informs the lesson-development
+process at many levels.
 
 ### Goals for the BoF
 
@@ -59,19 +67,38 @@ ensure that we are aligned with current HPC best practices, and to help the HPC
 Carpentries development team prioritize efforts for successor lessons in light
 of the changing landscape of current HPC practice.
 
-MPI remains a very popular parallel framework, but the community of novice HPC
-users may be using codes for which the MPI details are hidden, or which use
-entirely different parallel frameworks. What is the right level of detail to
-address parallel frameworks in the introductory and advanced levels?
+We plan discuss the following strategic topics:
 
-There are many languages in which parallel and HPC codes are written, including
-legacy Fortran codes, low-level C and C++ codes, and newer HPC codes written in
-Python, Julia, or other parallel languages. How can we provide relevant
-information across these communities, while retaining pedagogical rigor?
+1. For people who have used the existing material, we are interested in 
+   positive and negative aspects of the experience.
 
+    - Was the HPC Carpentry material used stand-alone, or in combination with other material?
+    - What sequence was used? 
+
+2. Our existing lessons are not uniformly developed, and we have many good ideas for future lessons.
+
+    - Where should we focus efforts for future lessons?
+    - Languages? Julia? Chapel? Python?
+    - Frameworks? MPI? Dask? Containers?
+
+3. Should the lessons be teachable as stand-alone sessions, with resultant overlap of material, or should the lessons form a "deck" that workshop coordinators can mix and match?
+
+4. The current HPC Intro lesson has templates for customization to local resources. There is obvious tension between having flexible templates versus ease of set-up.
+
+    - How much templating is useful? At what point does it become burdensome?
+    - Should the material be adapted to permanent on-premise resources, or transient cloud resources?
+
+5. What duration of workshop is practical for users of this material?
+
+    - Half-day?
+    - Full day?
+    - Two days?
+
+  
 ## Interactivity
 
-Approximately 2/3 to 3/4 of the session will be interactive.
+Approximately 3/4 of the session will be interactive, polling the audience 
+on the questions above.
 
 ## Format of the non-audience-participation portion
 
@@ -96,8 +123,8 @@ participants got together at SC18.
 
 ## Time, expected attendance, keywords
 
- - We expect the session will last 2.5 to 3 hours.
- - We expect around 20 participants.
+ - We expect the session will last 1.5 hours.
+ - We expect around 50 participants.
  - Carpentries, carpentry, education, new users
 
 ## Website link:
@@ -109,7 +136,7 @@ participants got together at SC18.
 [1]: https://hpc-carpentry.org
 [2]: https://carpentries.org
 [3]: https://github.com/carpentries-incubator/hpc-intro
-[4]: https://github.com/hpc-carpentry/hpc-python
+[4]: https://github.com/hpc-carpentry/hpc-parallel-novice
 [5]: https://github.com/hpc-carpentry/hpc-chapel
 [6]: http://www.hpc-carpentry.org/contact/
 [7]: https://github.com/carpentries-incubator

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -86,7 +86,7 @@ No.
 
 The BoF will open with a presentation of the current state of the lessons,
 including "pain points" identified by the development team, after which an open
-discussion will be held to solicit feedback on thees points, and the questions
+discussion will be held to solicit feedback on these points, and the questions
 above, from the attendees.
 
 ## Prior BoFs?

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -14,7 +14,7 @@ It's possible to include a brief bio for these.
 
 ## Abstract:
 
-[HPC Carpentry][1] is a community and a set of lessons for introducing new
+[HPC Carpentry][1] is a community built around a set of community-contributed lessons for introducing new
 users to high-performance computing resources. As these resources
 become more common, the need for educational resources to bring users from a
 broad variety of technical backgrounds up to speed becomes more urgent. Based

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -1,0 +1,79 @@
+
+## Title: HPC Carpentry: Introducing New Users to HPC
+
+## Session Leaders
+
+ - Andrew Reid
+ - Trevor Keller
+ - Others?
+
+It's possible ot include a brief bio for these.
+
+## Topic Area
+
+ - Education
+
+## Abstract:
+
+[HPC Carpentry][1] is a community and a set of lessons for introducing new users to cluster-based high-performance computing resources.  As these resources become more common, the need for educational resources to bring users from a broad variety of technical backgrounds up to speed becomes more urgent.  Based on the pedagigically sound methods of the larger [Carpentries][2] method, lessons in active development include an [introduction][3] to the use of a queuing system, an introduction to [parallel programming in Python][4], and a lesson focusing on the [Chapel parallel langauge][5].  The introductory lesson is part of the Carpentries incubator program, and is on track to be incorporated in to the Carpentries as a regular lesson in the near future.
+
+  
+##  Long description:
+
+### Who we are
+
+The [HPC Carpentry][1] community, a volunteer group of high-performance computing practitioners lead by a [steering committee][6], has developed a number of introductory lessons for new users of HPC clusters. 
+
+### What Problem We Solve
+
+It is almost a cliche at this point that greater and greater computational capabilities are becoming increasingly affordable.  An under-appreciated consequence of this is that the range of backgrounds of new users of these resources is increasingly broad, and may not include knowledge of computer system configurations and file system layouts.  There is an evident on-going need to address the gap between the needs of these users and the capabilities and opportunities presented by the available HPC resources.
+
+The [HPC Carpentry][1] lessons address this gap, building on the pedagogically sound instructional methods of the larger [Carpentries][2] community to develop several lessons.  The best-developed of these, the [HPC Intro][3] lesson, was recently submitted to the [Carpentries Incubator][7] program, and is on track to become an official [Carpentries][2] lesson.  Other important lessons in development include a [parallel python][4] lesson, and a lesson focusing on the [chapel][5] langauge.
+
+### Goals for the BoF
+
+During this BoF, we will gather community feedback on our progress to date, to ensure that we are aligned with current HPC best practices, and to help the HPC Carpentries development team prioritize efforts for successor lessons in light of the changing landscape of current HPC practice.  
+
+MPI remains a very popular parallel framework, but the community of novice HPC users may be using codes for which the MPI details are hidden, or which use entirely different parallel frameworks.  What is the right level of detail to address parallel frameworks in the introductory and advanced levels?
+
+There are many languages in which parallel and HPC codes are written, including legacy Fortran codes, low-level C and C++ codes, and newer HPC codes written in Python, Julia, or other parallel languages.  How can we provide relevant information across these communities, while retaining pedagogical rigor?
+
+## Interactivity
+
+Approximately 2/3 to 3/4 of the session will be interactive.
+
+## Format of the non-audience-participation portion
+
+Presentations by the session leaders, either with slides or walking through a lesson.
+
+## Commerical?
+
+No.
+
+## Format
+
+The BoF will open with a presentation of the current state of the lessons, including "pain points" identified by the develpoment team, after which an open discussion will be held to solicit feedback on theese points, and the questions above, from the attendees.
+
+## Prior BoFs?
+
+An HPC Carpentry BoF was held at SC17, and an informal group of about fifteen participants got together at SC18.
+
+## Time, expected attendance, keywords
+
+ - We expect the session will last 2.5 to 3 hours.
+ - We expect around 20 participants.
+ - Carpentries, carpentry, education, new users
+
+## Website link:
+
+[HPC Carpentry][1].
+
+
+
+[1]: https://hpc-carpentry.org
+[2]: https://carpentries.org
+[3]: https://github.com/carpentries-incubator/hpc-intro
+[4]: https://github.com/hpc-carpentry/hpc-python
+[5]: https://github.com/hpc-carpentry/hpc-chapel
+[6]: http://www.hpc-carpentry.org/contact/
+[7]: https://github.com/carpentries-incubator

--- a/conferences/SC21/bof_draft.md
+++ b/conferences/SC21/bof_draft.md
@@ -7,7 +7,7 @@
  - Trevor Keller
  - Others?
 
-It's possible ot include a brief bio for these.
+It's possible to include a brief bio for these.
 
 ## Topic Area
 
@@ -15,7 +15,7 @@ It's possible ot include a brief bio for these.
 
 ## Abstract:
 
-[HPC Carpentry][1] is a community and a set of lessons for introducing new users to cluster-based high-performance computing resources.  As these resources become more common, the need for educational resources to bring users from a broad variety of technical backgrounds up to speed becomes more urgent.  Based on the pedagigically sound methods of the larger [Carpentries][2] method, lessons in active development include an [introduction][3] to the use of a queuing system, an introduction to [parallel programming in Python][4], and a lesson focusing on the [Chapel parallel langauge][5].  The introductory lesson is part of the Carpentries incubator program, and is on track to be incorporated in to the Carpentries as a regular lesson in the near future.
+[HPC Carpentry][1] is a community and a set of lessons for introducing new users to cluster-based high-performance computing resources.  As these resources become more common, the need for educational resources to bring users from a broad variety of technical backgrounds up to speed becomes more urgent.  Based on the pedagogically sound methods of the larger [Carpentries][2] method, lessons in active development include an [introduction][3] to the use of a queuing system, an introduction to [parallel programming in Python][4], and a lesson focusing on the [Chapel parallel language][5].  The introductory lesson is part of the Carpentries incubator program, and is on track to be incorporated in to the Carpentries as a regular lesson in the near future.
 
   
 ##  Long description:
@@ -28,7 +28,7 @@ The [HPC Carpentry][1] community, a volunteer group of high-performance computin
 
 It is almost a cliche at this point that greater and greater computational capabilities are becoming increasingly affordable.  An under-appreciated consequence of this is that the range of backgrounds of new users of these resources is increasingly broad, and may not include knowledge of computer system configurations and file system layouts.  There is an evident on-going need to address the gap between the needs of these users and the capabilities and opportunities presented by the available HPC resources.
 
-The [HPC Carpentry][1] lessons address this gap, building on the pedagogically sound instructional methods of the larger [Carpentries][2] community to develop several lessons.  The best-developed of these, the [HPC Intro][3] lesson, was recently submitted to the [Carpentries Incubator][7] program, and is on track to become an official [Carpentries][2] lesson.  Other important lessons in development include a [parallel python][4] lesson, and a lesson focusing on the [chapel][5] langauge.
+The [HPC Carpentry][1] lessons address this gap, building on the pedagogically sound instructional methods of the larger [Carpentries][2] community to develop several lessons.  The best-developed of these, the [HPC Intro][3] lesson, was recently submitted to the [Carpentries Incubator][7] program, and is on track to become an official [Carpentries][2] lesson.  Other important lessons in development include a [parallel python][4] lesson, and a lesson focusing on the [chapel][5] language.
 
 ### Goals for the BoF
 
@@ -46,13 +46,13 @@ Approximately 2/3 to 3/4 of the session will be interactive.
 
 Presentations by the session leaders, either with slides or walking through a lesson.
 
-## Commerical?
+## Commercial?
 
 No.
 
 ## Format
 
-The BoF will open with a presentation of the current state of the lessons, including "pain points" identified by the develpoment team, after which an open discussion will be held to solicit feedback on theese points, and the questions above, from the attendees.
+The BoF will open with a presentation of the current state of the lessons, including "pain points" identified by the development team, after which an open discussion will be held to solicit feedback on thees points, and the questions above, from the attendees.
 
 ## Prior BoFs?
 


### PR DESCRIPTION
The conferences directory kicks off with a draft of an SC21 birds-of-a-feather proposal. ([rendered version](https://github.com/hpc-carpentry/coordination/blob/conferences-directory/conferences/SC21/bof_draft.md))

*TK Edited to add: call for BOF submissions* 🠒 <https://sc21.supercomputing.org/submit/birds-feather-submissions>

> A BoF submission includes:
>
> * Session leader information;
> * Selection of a topic area that best fits your BoF (see below);
> * Abstract (100-word maximum);
> * Long description (500-word maximum) clearly stating goal(s), topic, relevance to the expected HPC audience, and the expected outcome; and
> * Session format information, including a description (150-word maximum) of how you plan to organize the BoF session.